### PR TITLE
Fix read-only error for Julia apptainer

### DIFF
--- a/software/Julia/base-julia/README.md
+++ b/software/Julia/base-julia/README.md
@@ -25,8 +25,8 @@ Container definition files for building Julia packages in a base Julia environme
 | *Type* | **Apptainer** | |
 | *OS* | Debian "bookworm" | |
 | *Base image* | **julia:1.10** | *[DockerHub](https://hub.docker.com/layers/library/julia/1.10.2-bookworm/images/sha256-9e937d5a591b59f2680e7c5d665bf96ad80029034f22638564ae59ad52b472b6?context=explore)* |
-| *Updated* | 2024-04-12 | *Andrew Owen* |
-| *Last tested on HTC* | 2024-04-12 | *Andrew Owen* |
+| *Updated* | 2024-06-12 | *Andrew Owen* |
+| *Last tested on HTC* | 2024-06-12 | *Amber Lim* |
 | *Last tested on HPC* | - | - |
 
 ### Build Notes

--- a/software/Julia/base-julia/base-julia.def
+++ b/software/Julia/base-julia/base-julia.def
@@ -3,11 +3,9 @@ From: julia:1.10
 
 %post
         export JULIA_DEPOT_PATH="/usr/local/share/julia"
-        export JULIA_PROJECT="/opt/julia"
 
         # Install your packages using the following command:
         julia -e 'using Pkg; Pkg.add("Cowsay"); Pkg.instantiate(); Pkg.precompile()'
 
 %environment
-        export JULIA_DEPOT_PATH="/usr/local/share/julia"
-        export JULIA_PROJECT="/opt/julia"
+        export JULIA_DEPOT_PATH="/tmp/:/usr/local/share/julia"


### PR DESCRIPTION
- Appending `/tmp/:` to the environment variable `JULIA_DEPOT_PATH` fixes read-only errors when submitting apptainer jobs to the HTC.
- Removed `JULIA_PROJECT` as it is not necessary to run the apptainer.