### PR TITLE
Update sleap.def

### DIFF
--- a/software/SLEAP/README.md
+++ b/software/SLEAP/README.md
@@ -31,6 +31,6 @@ Program overview: https://sleap.ai/index.html
 | *Type* | **Apptainer** | |
 | *OS* | Ubuntu | |
 | *Base image* | **condaforge/miniforge3:latest** | *DockerHub* |
-| *Updated* | 2024-02-23 | *Andrew Owen* |
-| *Last tested on HTC* | - | - |
+| *Updated* | 2024-09-27 | *Amber Lim* |
+| *Last tested on HTC* | 2024-09-23 | *Amber Lim* |
 | *Last tested on HPC* | - | - |

--- a/software/SLEAP/sleap.def
+++ b/software/SLEAP/sleap.def
@@ -5,10 +5,11 @@ From: condaforge/miniforge3:latest
         # Install some shared library requirements
         export DEBIAN_FRONTEND=noninteractive
         apt update -y
-        apt install -y ffmpeg libsm6 libxext6
+        apt install -y ffmpeg libsm6 libxext6 libc6 git
 
-        # Install Sleap
-        mamba create -y -n sleap -c conda-forge -c nvidia -c sleap -c anaconda sleap=1.3.3
+        # Install Sleap from git
+        git clone https://github.com/talmolab/sleap && cd sleap
+        mamba env create -f environment.yml -n sleap
 
         # Activate environment when starting container
         cat << EOF > $APPTAINER_ENVIRONMENT


### PR DESCRIPTION
The previous definition file for SLEAP would build a container, but the container could not run sleap commands without running into this error. (https://github.com/talmolab/sleap/issues/1428) For now, a workaround is to install the development version from github.