### PR TITLE
Fix permissions for /tmp in matlab definition files

### DIFF
--- a/software/Matlab/base-matlab/README.md
+++ b/software/Matlab/base-matlab/README.md
@@ -31,8 +31,8 @@ If you want to install additional toolboxes, see the example that installs the S
 | *Type* | **Apptainer** | |
 | *OS* | Ubuntu 22.04 | |
 | *Base image* | **mathworks/matlab-deps:r2022b** | *DockerHub* |
-| *Updated* | 2024-04-09 | *Andrew Owen* |
-| *Last tested on HTC* | 2024-04-09 | *Andrew Owen* |
+| *Updated* | 2025-01-16 | *Amber Lim* |
+| *Last tested on HTC* | 2025-01-16 | *Amber Lim* |
 | *Last tested on HPC* | - | - |
 
 ## [Dockerfile](Dockerfile)

--- a/software/Matlab/mcc-compiler/README.md
+++ b/software/Matlab/mcc-compiler/README.md
@@ -34,7 +34,7 @@ If you want to install additional toolboxes, append them to the end of the value
 | *OS* | Ubuntu 22.04 | |
 | *Base image* | **mathworks/matlab-deps:r2022b** | *DockerHub* |
 | *Updated* | 2025-01-16 | *Amber Lim* |
-| *Last tested on HTC* | 2025-01-16 | *Amber Lim* |
+| *Last tested on HTC* | 2024-04-11 | *Andrew Owen* |
 | *Last tested on HPC* | - | - |
 
 ## [Dockerfile](Dockerfile)

--- a/software/Matlab/mcc-compiler/README.md
+++ b/software/Matlab/mcc-compiler/README.md
@@ -33,8 +33,8 @@ If you want to install additional toolboxes, append them to the end of the value
 | *Type* | **Apptainer** | |
 | *OS* | Ubuntu 22.04 | |
 | *Base image* | **mathworks/matlab-deps:r2022b** | *DockerHub* |
-| *Updated* | 2024-04-12 | *Andrew Owen* |
-| *Last tested on HTC* | 2024-04-11 | *Andrew Owen* |
+| *Updated* | 2025-01-16 | *Amber Lim* |
+| *Last tested on HTC* | 2025-01-16 | *Amber Lim* |
 | *Last tested on HPC* | - | - |
 
 ## [Dockerfile](Dockerfile)

--- a/software/Matlab/mcc-compiler/mcc-compiler.def
+++ b/software/Matlab/mcc-compiler/mcc-compiler.def
@@ -31,6 +31,7 @@ export MATLAB_PRODUCT_LIST=$MATLAB_PRODUCT_LIST
 export MATLAB_INSTALL_LOCATION=$MATLAB_INSTALL_LOCATION
 EOF
 
+    chmod 777 /tmp
     apt-get update -y
     apt-get install -y --no-install-recommends \
         bzip2 \

--- a/software/Matlab/symbolic-math/README.md
+++ b/software/Matlab/symbolic-math/README.md
@@ -31,7 +31,7 @@ If you do not need any additional toolboxes, see the [base-matlab](../base-matla
 | *Type* | **Apptainer** | |
 | *OS* | Ubuntu 22.04 | |
 | *Base image* | **mathworks/matlab-deps:r2022b** | *DockerHub* |
-| *Updated* | 2024-04-09 | *Andrew Owen* |
+| *Updated* | 2025-01-16 | *Amber Lim* |
 | *Last tested on HTC* | 2024-04-09 | *Andrew Owen* |
 | *Last tested on HPC* | - | - |
 

--- a/software/Matlab/symbolic-math/symbolic-math.def
+++ b/software/Matlab/symbolic-math/symbolic-math.def
@@ -31,6 +31,7 @@ export MATLAB_PRODUCT_LIST=$MATLAB_PRODUCT_LIST
 export MATLAB_INSTALL_LOCATION=$MATLAB_INSTALL_LOCATION
 EOF
 
+    chmod 777 /tmp
     apt-get update -y
     apt-get install -y --no-install-recommends \
         bzip2 \


### PR DESCRIPTION
Also updated dates in readmes. Only one tested was base-matlab.def