### PR TITLE
Update conda-pytorch recipes

### DIFF
--- a/software/Conda/conda-pytorch/Dockerfile
+++ b/software/Conda/conda-pytorch/Dockerfile
@@ -1,3 +1,4 @@
-FROM continuumio/miniconda3:latest
+FROM condaforge/miniforge3:25.3.0-3
 
-RUN conda install -y pytorch torchvision torchaudio pytorch-cuda=12.1 -c pytorch -c nvidia
+RUN conda install python=3.11
+RUN conda install -y pytorch torchvision torchaudio cuda-version=12.8 -c conda-forge -c nvidia

--- a/software/Conda/conda-pytorch/Dockerfile
+++ b/software/Conda/conda-pytorch/Dockerfile
@@ -1,4 +1,3 @@
 FROM condaforge/miniforge3:25.3.0-3
 
-RUN conda install python=3.11
-RUN conda install -y pytorch torchvision torchaudio cuda-version=12.8 -c conda-forge -c nvidia
+RUN CONDA_OVERRIDE_CUDA=12.8 conda install --channel conda-forge pytorch-gpu torchvision torchaudio cuda-version=12.8

--- a/software/Conda/conda-pytorch/Dockerfile
+++ b/software/Conda/conda-pytorch/Dockerfile
@@ -1,3 +1,3 @@
 FROM condaforge/miniforge3:25.3.0-3
 
-RUN CONDA_OVERRIDE_CUDA=12.8 conda install --channel conda-forge pytorch-gpu torchvision torchaudio cuda-version=12.8
+RUN CONDA_OVERRIDE_CUDA=12.9 conda install --channel conda-forge pytorch-gpu torchvision torchaudio cuda-version=12.9

--- a/software/Conda/conda-pytorch/README.md
+++ b/software/Conda/conda-pytorch/README.md
@@ -31,10 +31,10 @@ Installation command taken from the [PyTorch website](https://pytorch.org/get-st
 | | | |
 | ---: | :--- | :--- |
 | *Type* | **Apptainer** | |
-| *OS* | Debian "bullseye" | |
-| *Base image* | **continuumio/miniconda3:latest** | *DockerHub* |
-| *Updated* | 2024-04-15 | *Andrew Owen* |
-| *Last tested on HTC* | 2024-04-15 | *Andrew Owen* |
+| *OS* | Ubuntu 24.04.02 LTS | |
+| *Base image* | **condaforge/miniforge3:25.3.0-3** | *DockerHub* |
+| *Updated* | 2025-11-18 | *Amber Lim* |
+| *Last tested on HTC* | 2025-11-18 | *Amber lim* |
 | *Last tested on HPC* | - | - |
 
 ## [Dockerfile](Dockerfile)
@@ -42,8 +42,8 @@ Installation command taken from the [PyTorch website](https://pytorch.org/get-st
 | | | |
 | ---: | :--- | :--- |
 | *Type* | **Dockerfile** | |
-| *OS* | Debian "bullseye" | |
-| *Base image* | **continuumio/miniconda3:latest** | *DockerHub* |
-| *Updated* | 2024-05-10 | *Andrew Owen* |
+| *OS* | Ubuntu 24.04.02 LTS | |
+| *Base image* | **condaforge/miniforge3:25.3.0-3** | *DockerHub* |
+| *Updated* | 2025-11-18 | *Amber Lim* |
 | *Last tested on HTC* | - | - |
 | *Last tested on HPC* | - | - |

--- a/software/Conda/conda-pytorch/README.md
+++ b/software/Conda/conda-pytorch/README.md
@@ -36,7 +36,7 @@ This recipe is especially useful for
 | *OS* | Ubuntu 24.04.02 LTS | |
 | *Base image* | **condaforge/miniforge3:25.3.0-3** | *DockerHub* |
 | *Updated* | 2025-11-18 | *Amber Lim* |
-| *Last tested on HTC* | 2025-11-18 | *Amber lim* |
+| *Last tested on HTC* | 2025-11-18 | *Amber lim, Matthew Feickert* |
 | *Last tested on HPC* | - | - |
 
 ## [Dockerfile](Dockerfile)
@@ -46,6 +46,6 @@ This recipe is especially useful for
 | *Type* | **Dockerfile** | |
 | *OS* | Ubuntu 24.04.02 LTS | |
 | *Base image* | **condaforge/miniforge3:25.3.0-3** | *DockerHub* |
-| *Updated* | 2025-11-18 | *Amber Lim* |
+| *Updated* | 2025-11-18 | *Amber Lim, Matthew Feickert* |
 | *Last tested on HTC* | - | - |
 | *Last tested on HPC* | - | - |

--- a/software/Conda/conda-pytorch/README.md
+++ b/software/Conda/conda-pytorch/README.md
@@ -22,9 +22,11 @@ This recipe is especially useful for
 * installing older versions of PyTorch, which may not have official containers on DockerHub
 * installing PyTorch in combination with other conda packages
 
-## Build Notes
+## Choosing a CUDA Version
 
-Installation command taken from the [PyTorch website](https://pytorch.org/get-started/locally/) using the options "Stable, Linux, Conda, Python, CUDA 12.1".
+* Our recipes use CUDA 12.9, since they are compatible with most of our GPU machines.
+* You may consider using CUDA 13 instead. However, note that they will not be backwards compatible with older machines. We recommend using `gpus_minimum_capability = 8.0` in your HTCondor submit files when using jobs with containers with CUDA 13.
+
 
 ## [conda-pytorch.def](conda-pytorch.def)
 

--- a/software/Conda/conda-pytorch/conda-pytorch.def
+++ b/software/Conda/conda-pytorch/conda-pytorch.def
@@ -2,4 +2,4 @@ Bootstrap: docker
 From: condaforge/miniforge3:25.3.0-3
 
 %post
-    CONDA_OVERRIDE_CUDA=12.8 conda install --channel conda-forge pytorch-gpu torchvision torchaudio cuda-version=12.8
+    CONDA_OVERRIDE_CUDA=12.9 conda install --channel conda-forge pytorch-gpu torchvision torchaudio cuda-version=12.9

--- a/software/Conda/conda-pytorch/conda-pytorch.def
+++ b/software/Conda/conda-pytorch/conda-pytorch.def
@@ -2,6 +2,4 @@ Bootstrap: docker
 From: condaforge/miniforge3:25.3.0-3
 
 %post
-    # Need Python 3.11 or older to support conda-forge pytorch
-    conda install python=3.11
-    conda install -y pytorch torchvision torchaudio cuda-version=12.8 -c conda-forge -c nvidia
+    CONDA_OVERRIDE_CUDA=12.8 conda install --channel conda-forge pytorch-gpu torchvision torchaudio cuda-version=12.8

--- a/software/Conda/conda-pytorch/conda-pytorch.def
+++ b/software/Conda/conda-pytorch/conda-pytorch.def
@@ -1,5 +1,7 @@
 Bootstrap: docker
-From: continuumio/miniconda3:latest
+From: condaforge/miniforge3:25.3.0-3
 
 %post
-    conda install -y pytorch torchvision torchaudio pytorch-cuda=12.1 -c pytorch -c nvidia
+    # Need Python 3.11 or older to support conda-forge pytorch
+    conda install python=3.11
+    conda install -y pytorch torchvision torchaudio cuda-version=12.8 -c conda-forge -c nvidia

--- a/software/PyTorch/README.md
+++ b/software/PyTorch/README.md
@@ -20,7 +20,7 @@ Container definition files for using the PyTorch program with NVIDIA CUDA librar
 
 Our recipes are based off of [NVIDIA's Pytorch containers](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch), which come prepackaged with many common python libraries, such as `scipy`, `numpy`, and `matplotlib`, and system packages like `git`, `wget`, `cmake`, and `vim`/`nano`.
 
-Conda's version of Pytorch is deprecated. You will no longer be able to use Conda to install Pytorch.
+To install Pytorch with conda, see our [conda-pytorch recipes](../Conda/conda-pytorch/).
 
 If you do not need to add any other packages, you can directly use NVIDIA's PyTorch containers in your jobs by adding the following line:
 


### PR DESCRIPTION
Updates to the conda-pytorch recipe:

* Changed base image to `condaforge/miniforge`
* Uses Python 3.11. Python 3.12 is not currently compatible with conda-forge's Pytorch
* Update `cuda-version` to 12.8